### PR TITLE
Feat/add usecase for self healing when app hash occurred

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"time"
 )
 
 func init() {
@@ -160,7 +161,7 @@ type SyncInfoPodStatus struct {
 	Error *string `json:"error,omitempty"`
 
 	// +optional
-	HeightRetainTime *Duration `json:"heightRetainTime"`
+	HeightRetainTime *time.Duration `json:"heightRetainTime"`
 }
 
 type FullNodeSnapshotStatus struct {

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -158,6 +158,9 @@ type SyncInfoPodStatus struct {
 	// Error message if unable to fetch consensus state.
 	// +optional
 	Error *string `json:"error,omitempty"`
+
+	// +optional
+	HeightRetainTime *Duration `json:"heightRetainTime"`
 }
 
 type FullNodeSnapshotStatus struct {

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"encoding/json"
 	blockchain_toml "github.com/bharvest-devops/blockchain-toml"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -161,7 +162,27 @@ type SyncInfoPodStatus struct {
 	Error *string `json:"error,omitempty"`
 
 	// +optional
-	HeightRetainTime *time.Duration `json:"heightRetainTime"`
+	HeightRetainTime *Duration `json:"heightRetainTime"`
+}
+
+type Duration time.Duration
+
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	var durationStr string
+	if err := json.Unmarshal(data, &durationStr); err != nil {
+		return err
+	}
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return err
+	}
+	*d = Duration(duration)
+	return nil
+}
+
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	durationStr := time.Duration(*d).String()
+	return json.Marshal(durationStr)
 }
 
 type FullNodeSnapshotStatus struct {

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -17,12 +17,10 @@ limitations under the License.
 package v1
 
 import (
-	"encoding/json"
 	blockchain_toml "github.com/bharvest-devops/blockchain-toml"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
 )
 
 func init() {
@@ -162,27 +160,7 @@ type SyncInfoPodStatus struct {
 	Error *string `json:"error,omitempty"`
 
 	// +optional
-	HeightRetainTime *Duration `json:"heightRetainTime"`
-}
-
-type Duration time.Duration
-
-func (d *Duration) UnmarshalJSON(data []byte) error {
-	var durationStr string
-	if err := json.Unmarshal(data, &durationStr); err != nil {
-		return err
-	}
-	duration, err := time.ParseDuration(durationStr)
-	if err != nil {
-		return err
-	}
-	*d = Duration(duration)
-	return nil
-}
-
-func (d *Duration) MarshalJSON() ([]byte, error) {
-	durationStr := time.Duration(*d).String()
-	return json.Marshal(durationStr)
+	HeightRetainTime *metav1.Duration `json:"heightRetainTime"`
 }
 
 type FullNodeSnapshotStatus struct {

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -160,7 +160,7 @@ type SyncInfoPodStatus struct {
 	Error *string `json:"error,omitempty"`
 
 	// +optional
-	HeightRetainTime *metav1.Duration `json:"heightRetainTime"`
+	HeightRetainTime *metav1.Duration `json:"heightRetainTime,omitempty"`
 }
 
 type FullNodeSnapshotStatus struct {

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -65,7 +65,7 @@ type HeightDriftMitigationSpec struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Schemaless
 	// +optional
-	ThresholdTime Duration `json:"thresholdTime"`
+	ThresholdTime metav1.Duration `json:"thresholdTime"`
 }
 
 type SelfHealingStatus struct {

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -64,6 +64,7 @@ type HeightDriftMitigationSpec struct {
 	// +kubebuilder:validation:Minimum:=1
 	ThresholdHeight uint32 `json:"thresholdHeight"`
 
+	// +kubebuilder:printcolumn:type=string
 	// +optional
 	ThresholdTime Duration `json:"thresholdTime"`
 }

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 // SelfHealingController is the canonical controller name.
@@ -66,7 +65,7 @@ type HeightDriftMitigationSpec struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Schemaless
 	// +optional
-	ThresholdTime time.Duration `json:"thresholdTime"`
+	ThresholdTime Duration `json:"thresholdTime"`
 }
 
 type SelfHealingStatus struct {

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -64,6 +64,7 @@ type HeightDriftMitigationSpec struct {
 	// +kubebuilder:validation:Minimum:=1
 	ThresholdHeight uint32 `json:"thresholdHeight"`
 
+	// +optional
 	ThresholdTime Duration `json:"thresholdTime"`
 }
 

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -64,7 +64,8 @@ type HeightDriftMitigationSpec struct {
 	// +kubebuilder:validation:Minimum:=1
 	ThresholdHeight uint32 `json:"thresholdHeight"`
 
-	// +kubebuilder:printcolumn:type=string
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Schemaless
 	// +optional
 	ThresholdTime Duration `json:"thresholdTime"`
 }

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"encoding/json"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
@@ -67,25 +66,7 @@ type HeightDriftMitigationSpec struct {
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Schemaless
 	// +optional
-	ThresholdTime Duration `json:"thresholdTime"`
-}
-
-type Duration time.Duration
-
-// UnmarshalJSON implements the json.Unmarshaler interface for Duration
-func (d *Duration) UnmarshalJSON(data []byte) error {
-	// Unmarshal the JSON data into a string
-	var str string
-	if err := json.Unmarshal(data, &str); err != nil {
-		return err
-	}
-	// Parse the duration string
-	duration, err := time.ParseDuration(str)
-	if err != nil {
-		return err
-	}
-	*d = Duration(duration)
-	return nil
+	ThresholdTime time.Duration `json:"thresholdTime"`
 }
 
 type SelfHealingStatus struct {

--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -132,7 +132,7 @@ func (r *SelfHealingReconciler) mitigateHeightDrift(ctx context.Context, reporte
 		deleted++
 	}
 	if deleted > 0 {
-		msg := fmt.Sprintf("Height lagged behind by %d or more blocks; deleted pod(s)", crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdHeight)
+		msg := fmt.Sprintf("Height lagged behind by more than %d blocks or a certain amount of time(%d); deleted pod(s)", crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdHeight, crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime)
 		reporter.RecordInfo("HeightDriftMitigation", msg)
 	}
 }

--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -132,7 +132,7 @@ func (r *SelfHealingReconciler) mitigateHeightDrift(ctx context.Context, reporte
 		deleted++
 	}
 	if deleted > 0 {
-		msg := fmt.Sprintf("Height lagged behind by %d or more blocks; deleted pod(s)", crd.Spec.SelfHeal.HeightDriftMitigation.Threshold)
+		msg := fmt.Sprintf("Height lagged behind by %d or more blocks; deleted pod(s)", crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdHeight)
 		reporter.RecordInfo("HeightDriftMitigation", msg)
 	}
 }

--- a/internal/cosmos/cache_controller.go
+++ b/internal/cosmos/cache_controller.go
@@ -3,6 +3,7 @@ package cosmos
 import (
 	"context"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 	"time"
 
@@ -144,6 +145,7 @@ func (c *CacheController) Reconcile(ctx context.Context, req reconcile.Request) 
 			c.collectFromPods(cctx, reporter, req.NamespacedName)
 			return nil
 		})
+
 	}
 
 	return finishResult, nil
@@ -159,6 +161,7 @@ func (c *CacheController) Invalidate(controller client.ObjectKey, pods []string)
 				s.Status = CometStatus{}
 				s.Err = fmt.Errorf("invalidated")
 				s.TS = now
+				s.HeightRetainTime = metav1.Duration{Duration: 0}
 			}
 		}
 	}

--- a/internal/cosmos/cache_controller.go
+++ b/internal/cosmos/cache_controller.go
@@ -3,7 +3,6 @@ package cosmos
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 	"time"
 
@@ -161,7 +160,6 @@ func (c *CacheController) Invalidate(controller client.ObjectKey, pods []string)
 				s.Status = CometStatus{}
 				s.Err = fmt.Errorf("invalidated")
 				s.TS = now
-				s.HeightRetainTime = metav1.Duration{Duration: 0}
 			}
 		}
 	}

--- a/internal/cosmos/status_collection.go
+++ b/internal/cosmos/status_collection.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 	"time"
 
@@ -17,7 +18,7 @@ type StatusItem struct {
 	Status           CometStatus
 	TS               time.Time
 	Err              error
-	HeightRetainTime time.Duration
+	HeightRetainTime metav1.Duration
 }
 
 // GetPod returns the pod.

--- a/internal/cosmos/status_collection.go
+++ b/internal/cosmos/status_collection.go
@@ -13,10 +13,11 @@ import (
 
 // StatusItem is a pod paired with its CometBFT status.
 type StatusItem struct {
-	Pod    *corev1.Pod
-	Status CometStatus
-	TS     time.Time
-	Err    error
+	Pod              *corev1.Pod
+	Status           CometStatus
+	TS               time.Time
+	Err              error
+	HeightRetainTime time.Duration
 }
 
 // GetPod returns the pod.

--- a/internal/cosmos/status_collection.go
+++ b/internal/cosmos/status_collection.go
@@ -2,7 +2,6 @@ package cosmos
 
 import (
 	"errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
 	"time"
 
@@ -14,11 +13,10 @@ import (
 
 // StatusItem is a pod paired with its CometBFT status.
 type StatusItem struct {
-	Pod              *corev1.Pod
-	Status           CometStatus
-	TS               time.Time
-	Err              error
-	HeightRetainTime metav1.Duration
+	Pod    *corev1.Pod
+	Status CometStatus
+	TS     time.Time
+	Err    error
 }
 
 // GetPod returns the pod.
@@ -66,7 +64,7 @@ func UpsertPod(coll *StatusCollection, pod *corev1.Pod) {
 			return
 		}
 	}
-	*coll = append(*coll, StatusItem{Pod: pod, TS: time.Now(), Err: errors.New("missing status"), HeightRetainTime: metav1.Duration{Duration: 0}})
+	*coll = append(*coll, StatusItem{Pod: pod, TS: time.Now(), Err: errors.New("missing status")})
 }
 
 // IntersectPods removes all pods from the collection that are not in the given list.

--- a/internal/cosmos/status_collection.go
+++ b/internal/cosmos/status_collection.go
@@ -66,7 +66,7 @@ func UpsertPod(coll *StatusCollection, pod *corev1.Pod) {
 			return
 		}
 	}
-	*coll = append(*coll, StatusItem{Pod: pod, TS: time.Now(), Err: errors.New("missing status")})
+	*coll = append(*coll, StatusItem{Pod: pod, TS: time.Now(), Err: errors.New("missing status"), HeightRetainTime: metav1.Duration{Duration: 0}})
 }
 
 // IntersectPods removes all pods from the collection that are not in the given list.

--- a/internal/cosmos/status_collector.go
+++ b/internal/cosmos/status_collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sort"
 	"time"
 
@@ -60,7 +61,9 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 			beforeHeight := statuses[i].Status.LatestBlockHeight()
 			statuses[i].Status = resp
 			if statuses[i].Status.LatestBlockHeight() == beforeHeight {
-				statuses[i].HeightRetainTime = statuses[i].HeightRetainTime + now.Sub(beforeTS)
+				statuses[i].HeightRetainTime = metav1.Duration{
+					Duration: statuses[i].HeightRetainTime.Duration + now.Sub(beforeTS),
+				}
 			}
 			return nil
 		})

--- a/internal/cosmos/status_collector.go
+++ b/internal/cosmos/status_collector.go
@@ -40,7 +40,6 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 		i := i
 		eg.Go(func() error {
 			pod := pods[i]
-			statuses[i].TS = now
 			statuses[i].Pod = &pod
 			ip := pod.Status.PodIP
 			if ip == "" {
@@ -56,7 +55,12 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 				statuses[i].Err = err
 				return nil
 			}
+			beforeHeight := statuses[i].Status.LatestBlockHeight()
 			statuses[i].Status = resp
+			if statuses[i].Status.LatestBlockHeight() == beforeHeight {
+				statuses[i].HeightRetainTime = statuses[i].HeightRetainTime + now.Sub(statuses[i].TS)
+			}
+			statuses[i].TS = now
 			return nil
 		})
 	}

--- a/internal/cosmos/status_collector.go
+++ b/internal/cosmos/status_collector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sort"
 	"time"
 
@@ -42,7 +41,6 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 		eg.Go(func() error {
 			pod := pods[i]
 			statuses[i].Pod = &pod
-			beforeTS := statuses[i].TS
 			statuses[i].TS = now
 			ip := pod.Status.PodIP
 			if ip == "" {
@@ -58,13 +56,7 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 				statuses[i].Err = err
 				return nil
 			}
-			beforeHeight := statuses[i].Status.LatestBlockHeight()
 			statuses[i].Status = resp
-			if statuses[i].Status.LatestBlockHeight() == beforeHeight {
-				statuses[i].HeightRetainTime = metav1.Duration{
-					Duration: statuses[i].HeightRetainTime.Duration + now.Sub(beforeTS),
-				}
-			}
 			return nil
 		})
 	}

--- a/internal/cosmos/status_collector.go
+++ b/internal/cosmos/status_collector.go
@@ -41,6 +41,8 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 		eg.Go(func() error {
 			pod := pods[i]
 			statuses[i].Pod = &pod
+			beforeTS := statuses[i].TS
+			statuses[i].TS = now
 			ip := pod.Status.PodIP
 			if ip == "" {
 				// Check for IP, so we don't pay overhead of making a request.
@@ -58,9 +60,8 @@ func (coll StatusCollector) Collect(ctx context.Context, pods []corev1.Pod) Stat
 			beforeHeight := statuses[i].Status.LatestBlockHeight()
 			statuses[i].Status = resp
 			if statuses[i].Status.LatestBlockHeight() == beforeHeight {
-				statuses[i].HeightRetainTime = statuses[i].HeightRetainTime + now.Sub(statuses[i].TS)
+				statuses[i].HeightRetainTime = statuses[i].HeightRetainTime + now.Sub(beforeTS)
 			}
-			statuses[i].TS = now
 			return nil
 		})
 	}

--- a/internal/fullnode/drift_detection.go
+++ b/internal/fullnode/drift_detection.go
@@ -2,6 +2,7 @@ package fullnode
 
 import (
 	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	cosmosv1 "github.com/bharvest-devops/cosmos-operator/api/v1"
@@ -34,11 +35,11 @@ func (d DriftDetection) LaggingPods(ctx context.Context, crd *cosmosv1.CosmosFul
 	synced := d.collector.Collect(ctx, client.ObjectKeyFromObject(crd)).Synced()
 
 	lagging = lo.FilterMap(synced, func(item cosmos.StatusItem, _ int) (*corev1.Pod, bool) {
-		var initDuration time.Duration
+		var initDuration metav1.Duration
 		if item.HeightRetainTime == initDuration {
 			return item.GetPod(), false
 		}
-		isLagging := item.HeightRetainTime >= time.Duration(crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime)
+		isLagging := item.HeightRetainTime.Duration >= crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime.Duration
 		return item.GetPod(), isLagging
 	})
 	if len(lagging) > 0 {

--- a/internal/fullnode/drift_detection.go
+++ b/internal/fullnode/drift_detection.go
@@ -2,6 +2,7 @@ package fullnode
 
 import (
 	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	cosmosv1 "github.com/bharvest-devops/cosmos-operator/api/v1"
@@ -34,8 +35,10 @@ func (d DriftDetection) LaggingPods(ctx context.Context, crd *cosmosv1.CosmosFul
 	synced := d.collector.Collect(ctx, client.ObjectKeyFromObject(crd)).Synced()
 
 	lagging = lo.FilterMap(synced, func(item cosmos.StatusItem, _ int) (*corev1.Pod, bool) {
-		if crd.Status.SyncInfo[item.GetPod().Name] != nil {
-			isLagging := crd.Status.SyncInfo[item.GetPod().Name].HeightRetainTime.Duration >= crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime.Duration
+		itemSyncInfo := crd.Status.SyncInfo[item.GetPod().Name]
+		thresholdTime := crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime.Duration
+		if itemSyncInfo != nil && itemSyncInfo.HeightRetainTime != nil && thresholdTime != new(metav1.Duration).Duration {
+			isLagging := itemSyncInfo.HeightRetainTime.Duration >= thresholdTime
 			return item.GetPod(), isLagging
 		} else {
 			return item.GetPod(), false

--- a/internal/fullnode/drift_detection.go
+++ b/internal/fullnode/drift_detection.go
@@ -34,6 +34,10 @@ func (d DriftDetection) LaggingPods(ctx context.Context, crd *cosmosv1.CosmosFul
 	synced := d.collector.Collect(ctx, client.ObjectKeyFromObject(crd)).Synced()
 
 	lagging = lo.FilterMap(synced, func(item cosmos.StatusItem, _ int) (*corev1.Pod, bool) {
+		var initDuration time.Duration
+		if item.HeightRetainTime == initDuration {
+			return item.GetPod(), false
+		}
 		isLagging := item.HeightRetainTime >= time.Duration(crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime)
 		return item.GetPod(), isLagging
 	})

--- a/internal/fullnode/drift_detection.go
+++ b/internal/fullnode/drift_detection.go
@@ -38,7 +38,7 @@ func (d DriftDetection) LaggingPods(ctx context.Context, crd *cosmosv1.CosmosFul
 		if item.HeightRetainTime == initDuration {
 			return item.GetPod(), false
 		}
-		isLagging := item.HeightRetainTime >= crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime
+		isLagging := item.HeightRetainTime >= time.Duration(crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime)
 		return item.GetPod(), isLagging
 	})
 	if len(lagging) > 0 {

--- a/internal/fullnode/drift_detection.go
+++ b/internal/fullnode/drift_detection.go
@@ -38,7 +38,7 @@ func (d DriftDetection) LaggingPods(ctx context.Context, crd *cosmosv1.CosmosFul
 		if item.HeightRetainTime == initDuration {
 			return item.GetPod(), false
 		}
-		isLagging := item.HeightRetainTime >= time.Duration(crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime)
+		isLagging := item.HeightRetainTime >= crd.Spec.SelfHeal.HeightDriftMitigation.ThresholdTime
 		return item.GetPod(), isLagging
 	})
 	if len(lagging) > 0 {

--- a/internal/fullnode/drift_detection_test.go
+++ b/internal/fullnode/drift_detection_test.go
@@ -55,7 +55,7 @@ func TestDriftDetection_LaggingPods(t *testing.T) {
 		} {
 			crd.Spec.SelfHeal = &cosmosv1.SelfHealSpec{}
 			crd.Spec.SelfHeal.HeightDriftMitigation = &cosmosv1.HeightDriftMitigationSpec{
-				Threshold: tt.Threshold,
+				ThresholdHeight: tt.Threshold,
 			}
 
 			detector.available = func(pods []*corev1.Pod, minReady time.Duration, now time.Time) []*corev1.Pod {
@@ -89,7 +89,7 @@ func TestDriftDetection_LaggingPods(t *testing.T) {
 		var crd cosmosv1.CosmosFullNode
 		crd.Spec.SelfHeal = &cosmosv1.SelfHealSpec{}
 		crd.Spec.SelfHeal.HeightDriftMitigation = &cosmosv1.HeightDriftMitigationSpec{
-			Threshold: 25,
+			ThresholdHeight: 25,
 		}
 
 		got := detector.LaggingPods(context.Background(), &crd)

--- a/internal/fullnode/status.go
+++ b/internal/fullnode/status.go
@@ -47,7 +47,7 @@ func SyncInfoStatus(
 		stat.InSync = ptr(!comet.Result.SyncInfo.CatchingUp)
 
 		beforeSyncInfo := crd.Status.SyncInfo[podName]
-		if beforeSyncInfo != nil && *beforeSyncInfo.Height == *stat.Height {
+		if beforeSyncInfo != nil && beforeSyncInfo.Height != nil && stat.Height != nil && *beforeSyncInfo.Height == *stat.Height {
 			retainDuration = metav1.Duration{
 				Duration: beforeSyncInfo.HeightRetainTime.Duration + stat.Timestamp.Sub(beforeSyncInfo.Timestamp.Time),
 			}

--- a/internal/fullnode/status.go
+++ b/internal/fullnode/status.go
@@ -43,7 +43,7 @@ func SyncInfoStatus(
 		}
 		stat.Height = ptr(comet.LatestBlockHeight())
 		stat.InSync = ptr(!comet.Result.SyncInfo.CatchingUp)
-		stat.HeightRetainTime = ptr(cosmosv1.Duration(item.HeightRetainTime))
+		stat.HeightRetainTime = ptr(item.HeightRetainTime)
 		status[podName] = &stat
 	}
 

--- a/internal/fullnode/status.go
+++ b/internal/fullnode/status.go
@@ -47,7 +47,7 @@ func SyncInfoStatus(
 		stat.InSync = ptr(!comet.Result.SyncInfo.CatchingUp)
 
 		beforeSyncInfo := crd.Status.SyncInfo[podName]
-		if beforeSyncInfo != nil && beforeSyncInfo.Height == stat.Height {
+		if beforeSyncInfo != nil && *beforeSyncInfo.Height == *stat.Height {
 			retainDuration = metav1.Duration{
 				Duration: beforeSyncInfo.HeightRetainTime.Duration + stat.Timestamp.Sub(beforeSyncInfo.Timestamp.Time),
 			}

--- a/internal/fullnode/status.go
+++ b/internal/fullnode/status.go
@@ -2,7 +2,6 @@ package fullnode
 
 import (
 	"context"
-
 	cosmosv1 "github.com/bharvest-devops/cosmos-operator/api/v1"
 	"github.com/bharvest-devops/cosmos-operator/internal/cosmos"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +31,10 @@ func SyncInfoStatus(
 	coll := collector.Collect(ctx, client.ObjectKeyFromObject(crd))
 
 	for _, item := range coll {
-		var stat cosmosv1.SyncInfoPodStatus
+		var (
+			stat           cosmosv1.SyncInfoPodStatus
+			retainDuration metav1.Duration
+		)
 		podName := item.GetPod().Name
 		stat.Timestamp = metav1.NewTime(item.Timestamp())
 		comet, err := item.GetStatus()
@@ -43,7 +45,18 @@ func SyncInfoStatus(
 		}
 		stat.Height = ptr(comet.LatestBlockHeight())
 		stat.InSync = ptr(!comet.Result.SyncInfo.CatchingUp)
-		stat.HeightRetainTime = ptr(item.HeightRetainTime)
+
+		beforeSyncInfo := crd.Status.SyncInfo[podName]
+		if beforeSyncInfo != nil && beforeSyncInfo.Height == stat.Height {
+			retainDuration = metav1.Duration{
+				Duration: beforeSyncInfo.HeightRetainTime.Duration + stat.Timestamp.Sub(beforeSyncInfo.Timestamp.Time),
+			}
+			stat.HeightRetainTime = &retainDuration
+		} else {
+			retainDuration = metav1.Duration{Duration: 0}
+			stat.HeightRetainTime = &retainDuration
+		}
+
 		status[podName] = &stat
 	}
 

--- a/internal/fullnode/status.go
+++ b/internal/fullnode/status.go
@@ -43,6 +43,7 @@ func SyncInfoStatus(
 		}
 		stat.Height = ptr(comet.LatestBlockHeight())
 		stat.InSync = ptr(!comet.Result.SyncInfo.CatchingUp)
+		stat.HeightRetainTime = ptr(cosmosv1.Duration(item.HeightRetainTime))
 		status[podName] = &stat
 	}
 

--- a/internal/fullnode/status.go
+++ b/internal/fullnode/status.go
@@ -43,7 +43,7 @@ func SyncInfoStatus(
 		}
 		stat.Height = ptr(comet.LatestBlockHeight())
 		stat.InSync = ptr(!comet.Result.SyncInfo.CatchingUp)
-		stat.HeightRetainTime = ptr(item.HeightRetainTime)
+		stat.HeightRetainTime = ptr(cosmosv1.Duration(item.HeightRetainTime))
 		status[podName] = &stat
 	}
 

--- a/internal/fullnode/status_test.go
+++ b/internal/fullnode/status_test.go
@@ -65,8 +65,8 @@ func TestSyncInfoStatus(t *testing.T) {
 
 		return cosmos.StatusCollection{
 			// Purposefully out of order to test sorting.
-			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}}, Status: notInSync, TS: ts, HeightRetainTime: time.Duration(10000000000)},
-			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, Status: inSync, TS: ts, HeightRetainTime: time.Duration(10000000000)},
+			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}}, Status: notInSync, TS: ts, HeightRetainTime: metav1.Duration{Duration: time.Duration(10000000000)}},
+			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, Status: inSync, TS: ts, HeightRetainTime: metav1.Duration{Duration: time.Duration(10000000000)}},
 			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, Err: errors.New("some error"), TS: ts},
 		}
 	}
@@ -77,13 +77,13 @@ func TestSyncInfoStatus(t *testing.T) {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(9999)),
 			InSync:           ptr(false),
-			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
+			HeightRetainTime: ptr(metav1.Duration{Duration: time.Duration(10000000000)}),
 		},
 		"pod-1": {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(10000)),
 			InSync:           ptr(true),
-			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
+			HeightRetainTime: ptr(metav1.Duration{Duration: time.Duration(10000000000)}),
 		},
 		"pod-2": {
 			Timestamp: wantTS,

--- a/internal/fullnode/status_test.go
+++ b/internal/fullnode/status_test.go
@@ -77,13 +77,13 @@ func TestSyncInfoStatus(t *testing.T) {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(9999)),
 			InSync:           ptr(false),
-			HeightRetainTime: ptr(time.Duration(10000000000)),
+			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
 		},
 		"pod-1": {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(10000)),
 			InSync:           ptr(true),
-			HeightRetainTime: ptr(time.Duration(10000000000)),
+			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
 		},
 		"pod-2": {
 			Timestamp: wantTS,

--- a/internal/fullnode/status_test.go
+++ b/internal/fullnode/status_test.go
@@ -65,8 +65,8 @@ func TestSyncInfoStatus(t *testing.T) {
 
 		return cosmos.StatusCollection{
 			// Purposefully out of order to test sorting.
-			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}}, Status: notInSync, TS: ts},
-			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, Status: inSync, TS: ts},
+			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}}, Status: notInSync, TS: ts, HeightRetainTime: time.Duration(10000000000)},
+			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, Status: inSync, TS: ts, HeightRetainTime: time.Duration(10000000000)},
 			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, Err: errors.New("some error"), TS: ts},
 		}
 	}
@@ -74,14 +74,16 @@ func TestSyncInfoStatus(t *testing.T) {
 	wantTS := metav1.NewTime(ts)
 	want := map[string]*cosmosv1.SyncInfoPodStatus{
 		"pod-0": {
-			Timestamp: wantTS,
-			Height:    ptr(uint64(9999)),
-			InSync:    ptr(false),
+			Timestamp:        wantTS,
+			Height:           ptr(uint64(9999)),
+			InSync:           ptr(false),
+			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
 		},
 		"pod-1": {
-			Timestamp: wantTS,
-			Height:    ptr(uint64(10000)),
-			InSync:    ptr(true),
+			Timestamp:        wantTS,
+			Height:           ptr(uint64(10000)),
+			InSync:           ptr(true),
+			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
 		},
 		"pod-2": {
 			Timestamp: wantTS,

--- a/internal/fullnode/status_test.go
+++ b/internal/fullnode/status_test.go
@@ -77,13 +77,13 @@ func TestSyncInfoStatus(t *testing.T) {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(9999)),
 			InSync:           ptr(false),
-			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
+			HeightRetainTime: ptr(time.Duration(10000000000)),
 		},
 		"pod-1": {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(10000)),
 			InSync:           ptr(true),
-			HeightRetainTime: ptr(cosmosv1.Duration(10000000000)),
+			HeightRetainTime: ptr(time.Duration(10000000000)),
 		},
 		"pod-2": {
 			Timestamp: wantTS,

--- a/internal/fullnode/status_test.go
+++ b/internal/fullnode/status_test.go
@@ -65,8 +65,8 @@ func TestSyncInfoStatus(t *testing.T) {
 
 		return cosmos.StatusCollection{
 			// Purposefully out of order to test sorting.
-			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}}, Status: notInSync, TS: ts, HeightRetainTime: metav1.Duration{Duration: time.Duration(10000000000)}},
-			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, Status: inSync, TS: ts, HeightRetainTime: metav1.Duration{Duration: time.Duration(10000000000)}},
+			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}}, Status: notInSync, TS: ts},
+			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}}, Status: inSync, TS: ts},
 			{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}}, Err: errors.New("some error"), TS: ts},
 		}
 	}
@@ -77,13 +77,13 @@ func TestSyncInfoStatus(t *testing.T) {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(9999)),
 			InSync:           ptr(false),
-			HeightRetainTime: ptr(metav1.Duration{Duration: time.Duration(10000000000)}),
+			HeightRetainTime: ptr(metav1.Duration{Duration: time.Duration(0)}),
 		},
 		"pod-1": {
 			Timestamp:        wantTS,
 			Height:           ptr(uint64(10000)),
 			InSync:           ptr(true),
-			HeightRetainTime: ptr(metav1.Duration{Duration: time.Duration(10000000000)}),
+			HeightRetainTime: ptr(metav1.Duration{Duration: time.Duration(0)}),
 		},
 		"pod-2": {
 			Timestamp: wantTS,


### PR DESCRIPTION
This feature added on selfHealingController; before patching, it was only had threshold(currently, this key name changed into thresholdHeight).

Basically, the cacheController invokes statusController and statusController collects metrics every interval. 

When cacheController get new status, it compare each height(before/after) and if not changed, it adds height Retain Time.